### PR TITLE
Extra functionality to blog creation

### DIFF
--- a/blog.js
+++ b/blog.js
@@ -8,9 +8,9 @@ options = {
 program
   .version('0.1.1')
   .option('-t, --title [title]', 'give blog a title')
-  .option('-t, --subtitle [subtitle]', 'give blog asubtitle', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
-  .option('-t, --pagetitle [pagetitle]', 'give page a title')
-  .option('-t, --folder [folder]', 'give folder a title')
+  .option('-s, --subtitle [subtitle]', 'give blog asubtitle', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+  .option('-p, --pagetitle [pagetitle]', 'give page a title')
+  .option('-f, --folder [folder]', 'give folder a title')
   .parse(process.argv);
 
 function createBlog(title, subtitle, pagetitle, folder) {

--- a/blog.js
+++ b/blog.js
@@ -8,26 +8,34 @@ options = {
 program
   .version('0.1.1')
   .option('-t, --title [title]', 'give blog a title')
+  .option('-t, --subtitle [subtitle]', 'give blog asubtitle', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+  .option('-t, --pagetitle [pagetitle]', 'give page a title')
+  .option('-t, --folder [folder]', 'give folder a title')
   .parse(process.argv);
 
-function createBlog(title) {
-    if (!fs.existsSync(`./blog/${title}`)){
-        fs.mkdirSync(`./blog/${title}`);
+function createBlog(title, subtitle, pagetitle, folder) {
+    if (!fs.existsSync(`./blog/${folder}`)){
+        fs.mkdirSync(`./blog/${folder}`);
     }
-    fs.copyFile('./blog/blog_template.html', `./blog/${title}/index.html`, (err) => {
+    fs.copyFile('./blog/blog_template.html', `./blog/${folder}/index.html`, (err) => {
         if (err) throw err;
-        jsdom.fromFile(`./blog/${title}/index.html`, options).then(function (dom) {
+        jsdom.fromFile(`./blog/${folder}/index.html`, options).then(function (dom) {
             let window = dom.window, document = window.document;
             var style = document.createElement("link");
             style.setAttribute("rel","stylesheet")
             style.setAttribute("href","../../index.css");
             document.getElementsByTagName("head")[0].appendChild(style);
-            fs.writeFile(`./blog/${title}/index.html`, '<!DOCTYPE html>'+window.document.documentElement.outerHTML, function (error){
+            
+            document.getElementsByTagName("title")[0].textContent = pagetitle;
+            document.getElementById("blog_title").textContent = title;
+            document.getElementById("blog_sub_title").textContent = subtitle;
+
+            fs.writeFile(`./blog/${folder}/index.html`, '<!DOCTYPE html>'+window.document.documentElement.outerHTML, function (error){
                 if (error) throw error;
                 var blog_data = {
-                    "url_title": title,
-                    "title": "Lorem ipsum dolor sit amet",
-                    "sub_title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    "url_title": pagetitle,
+                    "title": title,
+                    "sub_title": subtitle,
                     "top_image": "https://images.unsplash.com/photo-1553748024-d1b27fb3f960?w=1450",
                     "visible": true }
                 fs.readFile("./blog/blog.json", function (err , data) {
@@ -47,7 +55,18 @@ function createBlog(title) {
 }
 
 if (program.title) {
-    createBlog(('%s', program.title));
+    if (!program.pagetitle) {
+        program.pagetitle = program.title;
+    }
+
+    if (!program.folder) {
+        program.folder = program.title;
+    }
+
+    program.folder = program.folder.replace(/[^A-Za-z0-9_-\s]/g, "").trim();
+    program.folder = program.folder.replace(/\s/g, "-");
+
+    createBlog(program.title, program.subtitle, program.pagetitle, program.folder);
 } else {
     console.log("provide a title to create a new blog");
 }

--- a/blog.js
+++ b/blog.js
@@ -8,7 +8,7 @@ options = {
 program
   .version('0.1.1')
   .option('-t, --title [title]', 'give blog a title')
-  .option('-s, --subtitle [subtitle]', 'give blog asubtitle', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+  .option('-s, --subtitle [subtitle]', 'give blog a subtitle', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
   .option('-p, --pagetitle [pagetitle]', 'give page a title')
   .option('-f, --folder [folder]', 'give folder a title')
   .parse(process.argv);


### PR DESCRIPTION
This provides three new arguments for creating a blog.
`-s, --subtitle "Subtitle Text" (The text below the title)`
`-p, --pagetitle "Page / URL title" (The text shown for tab)`
`-f, --folder "Blog folder" (The folder name where the blog is saved)`

`--pagetitle`, if it's not defined, `pagetitle` will be the same as `title`.
`--folder` takes a string. It replaces all whitespace characters with hyphens, and all special characters are removed. If no folder name is provided, `folder` will be the same as the `title`.