### PR TITLE
Improved username checking, fix for config.json writing blank

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -384,10 +384,10 @@ body{
     #work {
         margin:0px;
     }
-    #projects {
+    .projects {
         columns:1;
     }
-    #projects section {
+    .projects section {
         width:88%;
     }
     #blogs {

--- a/build.js
+++ b/build.js
@@ -81,7 +81,7 @@ async function populateConfig(sort, order, includeFork) {
 
 populateCSS();
 
-if (typeof program.name === 'string' && program.name !== '') {
+if (typeof program.name === 'string' && program.name.trim() !== '') {
     let sort = program.sort ? program.sort : 'created';
     let order = "asc";
     let includeFork = false;

--- a/build.js
+++ b/build.js
@@ -58,7 +58,7 @@ async function populateCSS() {
     themeSource = themeSource.toString('utf-8');
     let themeTemplate = hbs.compile(themeSource);
     let styles = themeTemplate({
-      'background': `${program.background || 'https://images.unsplash.com/photo-1553748024-d1b27fb3f960?w=1450'}`
+        'background': `${program.background || 'https://images.unsplash.com/photo-1553748024-d1b27fb3f960?w=1450'}`
     })
     /* Add the user-specified styles to the new stylesheet */
     await fs.appendFileAsync(stylesheet, styles);

--- a/build.js
+++ b/build.js
@@ -58,7 +58,7 @@ async function populateCSS() {
     themeSource = themeSource.toString('utf-8');
     let themeTemplate = hbs.compile(themeSource);
     let styles = themeTemplate({
-        'background': `${program.background || 'https://images.unsplash.com/photo-1553748024-d1b27fb3f960?w=1450'}`
+      'background': `${program.background || 'https://images.unsplash.com/photo-1553748024-d1b27fb3f960?w=1450'}`
     })
     /* Add the user-specified styles to the new stylesheet */
     await fs.appendFileAsync(stylesheet, styles);
@@ -81,7 +81,7 @@ async function populateConfig(sort, order, includeFork) {
 
 populateCSS();
 
-if (program.name) {
+if (typeof program.name === 'string' && program.name !== '') {
     let sort = program.sort ? program.sort : 'created';
     let order = "asc";
     let includeFork = false;

--- a/populate.js
+++ b/populate.js
@@ -113,14 +113,14 @@ module.exports.updateHTML = (username, sort, order, includeFork) => {
                     data[0].username = user.login;
                     data[0].name = user.name;
                     data[0].userimg = user.avatar_url;
-                    fs.writeFileSync('./dist/config.json', JSON.stringify(data, null, " "), function (err) {
+                    fs.writeFile('./dist/config.json', JSON.stringify(data, null, " "), function (err) {
                         if (err) throw err;
+                        console.log("Config file updated.");
                     });
                 });
                 fs.writeFile('dist/index.html', '<!DOCTYPE html>' + window.document.documentElement.outerHTML, function (error) {
                     if (error) throw error;
                     console.log("Build Complete");
-                    process.exit(0)
                 });
             } catch (error) {
                 console.log(error);

--- a/populate.js
+++ b/populate.js
@@ -113,7 +113,7 @@ module.exports.updateHTML = (username, sort, order, includeFork) => {
                     data[0].username = user.login;
                     data[0].name = user.name;
                     data[0].userimg = user.avatar_url;
-                    fs.writeFile('./dist/config.json', JSON.stringify(data, null, " "), function (err) {
+                    fs.writeFile('./dist/config.json', JSON.stringify(data, null, ' '), function (err) {
                         if (err) throw err;
                         console.log("Config file updated.");
                     });

--- a/populate.js
+++ b/populate.js
@@ -113,7 +113,7 @@ module.exports.updateHTML = (username, sort, order, includeFork) => {
                     data[0].username = user.login;
                     data[0].name = user.name;
                     data[0].userimg = user.avatar_url;
-                    fs.writeFile('./dist/config.json', JSON.stringify(data, null, ' '), function (err) {
+                    fs.writeFileSync('./dist/config.json', JSON.stringify(data, null, " "), function (err) {
                         if (err) throw err;
                     });
                 });


### PR DESCRIPTION
### build.js
- updated username checking to look for a non-empty string

previously, if no name was supplied, program.name would return a `function` and not exit early.

### populate.js
- removed `process.exit(0)` in ln.123 @ process.js

occasionally, this would close the process before the async `writeFile` at ln.116  was finished writing. This would result in a blank `config.json`. I think this was a contributing factor to issue #35.

Alternatively, you can keep `process.exit`, and instead use `fs.writeFileSync` on ln.116.


Awesome project! I'm happy to contribute further somehow. :)