### PR TITLE
Fix for ./dist/blog initialization issue

### DIFF
--- a/blog.js
+++ b/blog.js
@@ -14,6 +14,12 @@ program
   .parse(process.argv);
 
 function createBlog(title, subtitle, pagetitle, folder) {
+    // Checks to make sure this directory actually exists
+    // and creates it if it doesn't
+    if (!fs.existsSync(`./dist/blog/`)){
+        fs.mkdirSync(`./dist/blog/`, { recursive: true }, err => {});
+    }    
+    
     if (!fs.existsSync(`./dist/blog/${folder}`)){
         fs.mkdirSync(`./dist/blog/${folder}`, { recursive: true });
     }


### PR DESCRIPTION
When I went to create a blog for the first time, it kept throwing an error due to the fact that ./dist/blog did not exist. The recursive argument in the fs.mkdirSync function should have created it, but didn't. With this change, it now works on my system.