### PR TITLE
Horizontal ordering of Repos + Forks

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -272,11 +272,11 @@ body{
 }
 
 .projects {
+  margin-left: -15px; /* align section w/ heading above */
 }
 
 .projects a {
-  width: calc(50% - 35px); 
-  /* 30px is the gutter size in magic grid */
+  width: calc(50% - 30px);  /* 30px is the gutter size in magic grid */
   display: flex;
   text-decoration: none;
 }
@@ -405,6 +405,7 @@ body{
         margin:0px;
     }
     .projects {
+      margin-left: 0; /* remove neg margin to align w/ header */
     }
     .projects a {
       width: 100%;

--- a/assets/index.css
+++ b/assets/index.css
@@ -272,11 +272,17 @@ body{
 }
 
 .projects {
-    columns:2;
+}
+
+.projects a {
+  width: calc(50% - 35px); 
+  /* 30px is the gutter size in magic grid */
+  display: flex;
+  text-decoration: none;
 }
 
 .projects section {
-    width:85%;
+    width: 100%;
     padding:2.5vh 5%;
     display:inline-block;
     border-radius:5px;
@@ -284,7 +290,6 @@ body{
     border:1px solid rgb(0, 0, 0, 0.08);
     box-shadow:0px 0px 0px rgb(0, 0, 0, 0);
     transition:0.4s ease-in-out;
-    margin:2vh 0px;
     transform:scale(1);
 }
 
@@ -332,7 +337,6 @@ body{
 }
 
 #blogs {
-    columns:2;
 }
 
 #blogs section {
@@ -401,13 +405,14 @@ body{
         margin:0px;
     }
     .projects {
-        columns:1;
+    }
+    .projects a {
+      width: 100%;
     }
     .projects section {
         width:88%;
     }
     #blogs {
-        columns:1;
     }
     #blogs section {
         width:98%;

--- a/assets/index.css
+++ b/assets/index.css
@@ -276,7 +276,8 @@ body{
 }
 
 .projects a {
-  width: calc(50% - 30px);  /* 30px is the gutter size in magic grid */
+  /* 30px is the gutter size in magic grid */
+  width: calc(49% - 30px);  /* 49% avoids a weird single column on some wide screens */
   display: flex;
   text-decoration: none;
 }

--- a/assets/index.html
+++ b/assets/index.html
@@ -11,6 +11,7 @@
         integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"
         integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/magic-grid/dist/magic-grid.min.js"></script>
     <link rel="stylesheet" href="index.css">
 </head>
 
@@ -84,6 +85,33 @@
                 navigator.serviceWorker.register('service-worker.js');
             });
         }
+    </script>
+
+    <script>
+        const magicProjectsGrid = new MagicGrid({
+          container: '#work_section',
+          animate: false,
+          gutter: 30, // default gutter size
+          static: true,
+          useMin: false,
+          maxColumns: 2,
+          useTransform: true
+        });
+
+        const magicForksGrid = new MagicGrid({
+          container: '#forks_section',
+          animate: false,
+          gutter: 30, // default gutter size
+          static: true,
+          useMin: false,
+          maxColumns: 2,
+          useTransform: true
+        })
+
+        $('document').ready(() => {
+          magicProjectsGrid.listen();
+          magicForksGrid.listen();
+        });
     </script>
 </body>
 


### PR DESCRIPTION
- added ~1.5kb dependency (magic grid) + small script tag in `assets/index.html`

This PR sorts the orders the repos horizontally, rather than vertically (see my open issue #60 ). This way, the ordering and sort flags work as expected, rather than displaying the median repo at the top of the right column. 

I've attached a screenshot of the proposed update below, and you can visit it live at [http://bliden.github.io](http://bliden.github.io)

![Screenshot_20190529_140224](https://user-images.githubusercontent.com/27828594/58580370-f56f8d80-821a-11e9-953f-b6238dd89893.png)
