### PR TITLE
Added GitLab support

### DIFF
--- a/bin/gitfolio.js
+++ b/bin/gitfolio.js
@@ -18,6 +18,7 @@ program
     .option('-f, --fork', 'includes forks with repos')
     .option('-s, --sort [sort]', 'set default sort for repository', 'created')
     .option('-o, --order [order]', 'set default order on sort', 'asc')
+    .option('-l, --gitlab', 'search for the user on GitLab instead of GitHub')
     .action(buildCommand)
 
 program

--- a/build.js
+++ b/build.js
@@ -76,8 +76,9 @@ async function buildCommand(username, program) {
     let sort = program.sort ? program.sort : 'created';
     let order = program.order ? program.order : "asc";
     let includeFork = program.fork ? true : false;
+    let gitlab = program.gitlab ? true : false;
     await populateConfig(sort, order, includeFork);
-    updateHTML(('%s', username), sort, order, includeFork);
+    updateHTML(('%s', username), sort, order, includeFork, gitlab);
 }
 
 module.exports = {


### PR DESCRIPTION
Using the `--gitlab` switch, the generator will now pull data from GitLab instead of GitHub.

Changes:
- added the `--gitlab` switch option to the commander program and to the `updateHTML` function
- added code for querying the GitLab API instead of the GitHub API and mapping those values to the GitHub-standard

Inconsistencies between GitLab and GitHub data:
- The GitLab API does not publicly provide information about the origin of a forked repository
- The GitLab API does not have a `hireable` field.
- The GitLab API has another endpoint for languages. To find out the primary language of a project, one request per project would be necessary (this would maybe run against rate limits) - [Docs](https://docs.gitlab.com/ee/api/projects.html#languages)