### PR TITLE
Remove host workaround for emoji URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "commander": "^2.20.0",
     "ejs": "^2.6.2",
     "express": "^4.17.0",
-    "github-emoji": "^1.1.0",
+    "github-emoji": "^1.1.1",
     "got": "^9.6.0",
     "handlebars": "^4.1.2",
     "jsdom": "^15.1.0",

--- a/populate.js
+++ b/populate.js
@@ -18,14 +18,9 @@ function convertToEmoji(text) {
     });
     for (i = 0; i < str.length; i++) {
       if (emoji.URLS[str[i]] != undefined) {
-        var output = emoji.of(str[i]);
-        var emojiImage = output.url.replace(
-          "assets-cdn.github",
-          "github.githubassets"
-        );
         text = text.replace(
           `:${str[i]}:`,
-          `<img src="${emojiImage}" class="emoji">`
+          `<img src="${emoji.URLS[str[i]]}" class="emoji">`
         );
       }
     }


### PR DESCRIPTION
Hi team,

Thank you for using my small [github-emoji](https://www.npmjs.com/package/github-emoji). In previous version v1.1.0, host name `assets-cdn.github.com` was old. In new version v1.1.1, it [was fixed](https://github.com/rhysd/node-github-emoji/releases/tag/v1.1.1) as `github.githubassets.com` today.

In this repo, I noticed that you kindly did workaround for the host name issue and it is no longer necessary for v1.1.1. This patch will ensure to update github-emoji to v1.1.1 and removes the workaround.