### PR TITLE
Fixed blog link

### DIFF
--- a/populate.js
+++ b/populate.js
@@ -113,9 +113,9 @@ module.exports.updateHTML = (username, opts) => {
                 };"><i class="fas fa-envelope"></i> &nbsp; ${user.email}</span>
                 <span style="display:${
                   user.blog == null || !user.blog ? "none" : "block"
-                };"><i class="fas fa-link"></i> &nbsp; <a href="${user.blog}">${
+                };"><i class="fas fa-link"></i> &nbsp; <a href="http://${
             user.blog
-          }</a></span>
+          }">${user.blog}</a></span>
                 <span style="display:${
                   user.location == null || !user.location ? "none" : "block"
                 };"><i class="fas fa-map-marker-alt"></i> &nbsp;&nbsp; ${


### PR DESCRIPTION
Hello!
This small bug was found during making my gitfolio with **blog link.** 
There was a problem with link from user's info to the blog. If this link hasn't got http/https prefix, your template gives domain prefix and page becomes 404. 
For example, my github contains blog link to _emdobro.ru_ without https. After publishing this link became to _betchika99.github.io/emdobro.ru_, that isn't correct. 
My fix isn't very beautiful maybe, but it works and GitHub has the same solving for this problem. I just add prefix `http://` to user's blog link. If user's nginx works correctly, domains with https prefix will be caught too
Hope to be useful! See you! And thanks for this good theme :)