### PR TITLE
fix: blog top image overlay based on theme

### DIFF
--- a/assets/blog/blogTemplate.html
+++ b/assets/blog/blogTemplate.html
@@ -112,7 +112,7 @@
           user[0].name == null || !user[0].name ? "none" : "block"
         };">${user[0].name}</span>@${user[0].username}<b id="blog_time"></b>`;
 
-        if ((user[0].theme = "dark.css")) {
+        if ((user[0].theme === "dark.css")) {
           document.querySelector("#background_overlay").style.background =
             "linear-gradient(0deg, rgba(10, 10, 10, 1), rgba(10, 10, 10, 0.1))";
         } else {


### PR DESCRIPTION
This will fix the bug when adding background overlay for the blog top image based on `config.json`.


<img width="1096" alt="Screen Shot 2021-04-11 at 03 15 03" src="https://user-images.githubusercontent.com/15009059/114283505-4afe5d80-9a74-11eb-9e0f-740900588eeb.png">
<img width="1098" alt="Screen Shot 2021-04-11 at 03 15 13" src="https://user-images.githubusercontent.com/15009059/114283511-505ba800-9a74-11eb-9abf-ac78611fb1ec.png">
